### PR TITLE
Add locale.library localization with German translation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ fi
 CFLAGS="-m68020 -O2 -Wall -noixemul -fcommon -Isdk/include -Isrc"
 LDFLAGS="-noixemul -Lsdk/lib -Wl,--allow-multiple-definition"
 LIBS="-lamisslstubs -lsocket -lm"
-SOURCES="src/main.c src/http.c src/claude.c src/json_utils.c src/cJSON.c src/gui.c src/arexx_port.c src/config.c src/memory.c src/tools.c src/dt_identify.c"
+SOURCES="src/main.c src/http.c src/claude.c src/json_utils.c src/cJSON.c src/gui.c src/arexx_port.c src/config.c src/memory.c src/tools.c src/dt_identify.c src/locale.c"
 
 if [ "$USE_DOCKER" = "1" ]; then
     IMAGE="kareandersen/amiga-gcc"
@@ -78,6 +78,16 @@ echo '=== Linking FileType ==='
 echo '=== Done: FileType ==='
 ls -la FileType
 "
+    # Build mkcatalog on host and generate .catalog files
+    echo ""
+    echo "=== Building mkcatalog (host) ==="
+    cc -o "$PROJDIR/tools/mkcatalog" "$PROJDIR/tools/mkcatalog.c"
+    echo "=== Generating German catalog ==="
+    mkdir -p "$PROJDIR/Catalogs/Deutsch"
+    "$PROJDIR/tools/mkcatalog" "$PROJDIR/catalogs/deutsch.txt" "$PROJDIR/Catalogs/Deutsch/AmigaAI.catalog" deutsch
+    echo "=== Done: Catalogs/Deutsch/AmigaAI.catalog ==="
+    ls -la "$PROJDIR/Catalogs/Deutsch/AmigaAI.catalog"
+
 else
     echo "=== Using native $CC ($($CC --version | head -1)) ==="
     cd "$PROJDIR"
@@ -112,4 +122,14 @@ else
     $STRIP FileType
     echo "=== Done: FileType ==="
     ls -la FileType
+
+    # Build mkcatalog (host tool) and generate .catalog files
+    echo ""
+    echo "=== Building mkcatalog (host) ==="
+    cc -o tools/mkcatalog tools/mkcatalog.c
+    echo "=== Generating German catalog ==="
+    mkdir -p Catalogs/Deutsch
+    tools/mkcatalog catalogs/deutsch.txt Catalogs/Deutsch/AmigaAI.catalog deutsch
+    echo "=== Done: Catalogs/Deutsch/AmigaAI.catalog ==="
+    ls -la Catalogs/Deutsch/AmigaAI.catalog
 fi

--- a/catalogs/deutsch.txt
+++ b/catalogs/deutsch.txt
@@ -1,0 +1,186 @@
+; AmigaAI German Translation
+; Format: ID number followed by translated string on next line
+; Language: Deutsch
+;
+0
+Projekt
+1
+Einstellungen
+2
+Ged\xe4chtnis
+3
+Neues Gespr\xe4ch
+4
+Gespr\xe4ch speichern...
+5
+Gespr\xe4ch laden...
+6
+\xdcber...
+7
+Beenden
+8
+API-Schl\xfcssel...
+9
+Modell...
+10
+Systemvorgabe...
+11
+Ged\xe4chtnis anzeigen...
+12
+Ged\xe4chtnis hinzuf\xfcgen...
+13
+Ged\xe4chtnis l\xf6schen
+14
+_Senden
+15
+S_topp
+16
+_OK
+17
+_Abbrechen
+18
+Bereit.
+19
+Sende an Claude...
+20
+Anfrage abgebrochen.
+21
+Fehler
+22
+Gespr\xe4ch gel\xf6scht. Bereit.
+23
+Nachricht oder Befehl eingeben
+24
+F\xfchre Shell-Befehl aus...
+25
+Sende ARexx-Befehl...
+26
+Kein API-Schl\xfcssel - in Einstellungen konfigurieren
+27
+Willkommen bei AmigaAI 0.2
+28
+Nachricht eingeben und Enter dr\xfccken oder Senden klicken.
+29
+\033bDu:\033n
+30
+\033bClaude:\033n
+31
+\033b\033c--- Abgebrochen ---\033n
+32
+\033c--- Neues Gespr\xe4ch ---
+33
+\033b\033cFEHLER:\033n
+34
+Token: %d rein / %d raus | Nachrichten: %d
+35
+\033b\033cVerf\xfcgbare Befehle\033n
+36
+\033b/help\033n              - Diese Hilfe anzeigen
+37
+\033b/shell <cmd>\033n      - AmigaDOS-Befehl ausf\xfchren
+38
+\033b/arexx <port> <cmd>\033n - ARexx-Befehl senden
+39
+\033b/read <pfad>\033n      - Datei lesen
+40
+\033b/write <pfad> <text>\033n - In Datei schreiben
+41
+\033b/ports\033n            - \xd6ffentliche Ports auflisten
+42
+\033b/remember <text>\033n  - Eintrag merken
+43
+\033b/memory\033n           - Alle Eintr\xe4ge anzeigen
+44
+Anderer Text wird als Nachricht an Claude gesendet.
+45
+Cursor hoch/runter f\xfcr Eingabeverlauf.
+46
+Claude KI-Agent f\xfcr AmigaOS
+47
+Stack: AmiSSL v5, cJSON, MUI
+48
+Ged\xe4chtnis
+49
+Ged\xe4chtniseintrag hinzuf\xfcgen
+50
+Ged\xe4chtnis l\xf6schen
+51
+Fakt oder Pr\xe4ferenz zum Merken eingeben:
+52
+Ged\xe4chtniseintrag hinzugef\xfcgt.
+53
+Ged\xe4chtnis ist voll!
+54
+Noch keine Eintr\xe4ge gespeichert.
+55
+Noch keine Eintr\xe4ge gespeichert.\n\nVerwende Ged\xe4chtnis > Hinzuf\xfcgen oder tippe:\n/remember <fakt>
+56
+Alle Ged\xe4chtniseintr\xe4ge l\xf6schen?\nDies kann nicht r\xfcckg\xe4ngig gemacht werden.
+57
+Gesamtes Ged\xe4chtnis gel\xf6scht.
+58
+*_L\xf6schen|_Abbrechen
+59
+Modell ausw\xe4hlen
+60
+Modell: %s
+61
+Gespr\xe4ch speichern
+62
+Keine Nachrichten zum Speichern.
+63
+Serialisierung fehlgeschlagen.
+64
+Gespr\xe4ch gespeichert in chat.json
+65
+Speichern fehlgeschlagen!
+66
+Kein gespeichertes Gespr\xe4ch gefunden (chat.json).
+67
+Gespr\xe4chsdatei zu gro\xdf oder leer.
+68
+Kein Speicher mehr.
+69
+Fehler beim Lesen der Gespr\xe4chsdatei.
+70
+Gespr\xe4ch geladen (%d Nachrichten)
+71
+\033c--- Gespr\xe4ch geladen ---
+72
+Gespeichertes Gespr\xe4ch konnte nicht gelesen werden!
+73
+FEHLER: Kein Speicher beim L\xf6schen des Verlaufs
+74
+Unbekannter Fehler
+75
+\033bShell:\033n %s
+76
+\033bARexx:\033n %s > %s
+77
+Verwendung: /arexx <PORT> <Befehl>
+78
+\033bLesen:\033n %s
+79
+Verwendung: /write <Pfad> <Inhalt>
+80
+Fertig
+81
+Befehl fehlgeschlagen
+82
+\033b\xd6ffentliche Ports:\033n
+83
+Ports aufgelistet
+84
+Ged\xe4chtnis: %d Eintr\xe4ge
+85
+\033bWARNUNG:\033n Kein API-Schl\xfcssel konfiguriert!
+86
+Verwende Einstellungen > API-Schl\xfcssel oder setze ENV:AmigaAI/api_key
+87
+Ged\xe4chtnis: %d Eintr\xe4ge geladen
+88
+Systemvorgabe-Editor - kommt bald
+89
+Claude KI-Agent f\xfcr AmigaOS
+90
+API-Schl\xfcssel setzen: echo "key" > ENV:AmigaAI/api_key

--- a/instructions/ARexx/AMIGAAI.md
+++ b/instructions/ARexx/AMIGAAI.md
@@ -1,0 +1,30 @@
+# AMIGAAI ARexx Port
+
+Port name: AMIGAAI. This is your own ARexx port. Other programs can send commands to control you.
+
+## Commands
+- `ASK <text>` -- Send a question to Claude and return the response
+- `GETLAST` -- Return the last response from a previous ASK command
+- `CLEAR` -- Clear conversation history and last response
+- `SETMODEL <model>` -- Change the AI model (e.g. claude-sonnet-4-6)
+- `SETSYSTEM <prompt>` -- Change the system prompt
+- `MEMADD <text>` -- Add a persistent memory entry
+- `MEMCLEAR` -- Clear all persistent memory entries
+- `MEMCOUNT` -- Return the number of memory entries
+- `MEMORY` -- Return all memory entries as text
+- `QUIT` -- Quit AmigaAI
+
+## Return Codes
+- 0 = Success (result string available if RXFF_RESULT set)
+- 5 = Unknown command
+- 10 = Error (ASK failed, memory full)
+- 20 = Out of memory (CLEAR failed)
+
+## Example ARexx Script
+```rexx
+/* Ask Claude a question from another program */
+ADDRESS AMIGAAI
+OPTIONS RESULTS
+ASK "What is the Amiga?"
+SAY RESULT
+```

--- a/src/gui.c
+++ b/src/gui.c
@@ -1,4 +1,5 @@
 #include "gui.h"
+#include "locale.h"
 #include "texteditor_mcc.h"
 #include "version.h"
 
@@ -219,30 +220,30 @@ static Object *make_menu(void)
     Object *strip, *proj, *settings, *memory;
 
     /* --- Project menu items --- */
-    Object *mi_new      = mk_menuitem("New Chat",      "N", GUI_ID_NEW);
+    Object *mi_new      = mk_menuitem(GetString(MSG_MENU_NEW_CHAT), "N", GUI_ID_NEW);
     Object *mi_bar1     = mk_menuitem((const char *)NM_BARLABEL, NULL, 0);
-    Object *mi_save     = mk_menuitem("Save Chat...",  "S", GUI_ID_CHATSAVE);
-    Object *mi_load     = mk_menuitem("Load Chat...",  "L", GUI_ID_CHATLOAD);
+    Object *mi_save     = mk_menuitem(GetString(MSG_MENU_SAVE_CHAT), "S", GUI_ID_CHATSAVE);
+    Object *mi_load     = mk_menuitem(GetString(MSG_MENU_LOAD_CHAT), "L", GUI_ID_CHATLOAD);
     Object *mi_bar2     = mk_menuitem((const char *)NM_BARLABEL, NULL, 0);
-    Object *mi_about    = mk_menuitem("About...",      "?", GUI_ID_ABOUT);
+    Object *mi_about    = mk_menuitem(GetString(MSG_MENU_ABOUT), "?", GUI_ID_ABOUT);
     Object *mi_bar3     = mk_menuitem((const char *)NM_BARLABEL, NULL, 0);
-    Object *mi_quit     = mk_menuitem("Quit",          "Q", GUI_ID_QUIT);
+    Object *mi_quit     = mk_menuitem(GetString(MSG_MENU_QUIT), "Q", GUI_ID_QUIT);
 
     /* --- Settings menu items --- */
-    Object *mi_apikey   = mk_menuitem("API Key...",       NULL, GUI_ID_APIKEY);
-    Object *mi_model    = mk_menuitem("Model...",         NULL, GUI_ID_MODEL);
-    Object *mi_system   = mk_menuitem("System Prompt...", NULL, GUI_ID_SYSTEM);
+    Object *mi_apikey   = mk_menuitem(GetString(MSG_MENU_APIKEY),        NULL, GUI_ID_APIKEY);
+    Object *mi_model    = mk_menuitem(GetString(MSG_MENU_MODEL),         NULL, GUI_ID_MODEL);
+    Object *mi_system   = mk_menuitem(GetString(MSG_MENU_SYSTEM_PROMPT), NULL, GUI_ID_SYSTEM);
 
     /* --- Memory menu items --- */
-    Object *mi_memview  = mk_menuitem("View Memory...",   "M", GUI_ID_MEMVIEW);
-    Object *mi_memadd   = mk_menuitem("Add Memory...",    NULL, GUI_ID_MEMADD);
+    Object *mi_memview  = mk_menuitem(GetString(MSG_MENU_VIEW_MEMORY),  "M", GUI_ID_MEMVIEW);
+    Object *mi_memadd   = mk_menuitem(GetString(MSG_MENU_ADD_MEMORY),   NULL, GUI_ID_MEMADD);
     Object *mi_bar4     = mk_menuitem((const char *)NM_BARLABEL, NULL, 0);
-    Object *mi_memclear = mk_menuitem("Clear Memory",     NULL, GUI_ID_MEMCLEAR);
+    Object *mi_memclear = mk_menuitem(GetString(MSG_MENU_CLEAR_MEMORY), NULL, GUI_ID_MEMCLEAR);
 
     /* --- Project menu --- */
     {
         struct TagItem tags[] = {
-            { MUIA_Menu_Title,    (ULONG)"Project" },
+            { MUIA_Menu_Title,    (ULONG)GetString(MSG_MENU_PROJECT) },
             { MUIA_Family_Child,  (ULONG)mi_new },
             { MUIA_Family_Child,  (ULONG)mi_bar1 },
             { MUIA_Family_Child,  (ULONG)mi_save },
@@ -259,7 +260,7 @@ static Object *make_menu(void)
     /* --- Settings menu --- */
     {
         struct TagItem tags[] = {
-            { MUIA_Menu_Title,    (ULONG)"Settings" },
+            { MUIA_Menu_Title,    (ULONG)GetString(MSG_MENU_SETTINGS) },
             { MUIA_Family_Child,  (ULONG)mi_apikey },
             { MUIA_Family_Child,  (ULONG)mi_model },
             { MUIA_Family_Child,  (ULONG)mi_system },
@@ -271,7 +272,7 @@ static Object *make_menu(void)
     /* --- Memory menu --- */
     {
         struct TagItem tags[] = {
-            { MUIA_Menu_Title,    (ULONG)"Memory" },
+            { MUIA_Menu_Title,    (ULONG)GetString(MSG_MENU_MEMORY) },
             { MUIA_Family_Child,  (ULONG)mi_memview },
             { MUIA_Family_Child,  (ULONG)mi_memadd },
             { MUIA_Family_Child,  (ULONG)mi_bar4 },
@@ -373,7 +374,7 @@ int gui_open(struct Gui *gui)
     printf("  gui: creating send button...\n");
     {
         ULONG params[1];
-        params[0] = (ULONG)"_Send";
+        params[0] = (ULONG)GetString(MSG_BTN_SEND);
         gui->send_btn = MUI_MakeObjectA(MUIO_Button, params);
     }
     printf("  gui: send_btn=%p\n", (void *)gui->send_btn);
@@ -381,7 +382,7 @@ int gui_open(struct Gui *gui)
     printf("  gui: creating stop button...\n");
     {
         ULONG params[1];
-        params[0] = (ULONG)"S_top";
+        params[0] = (ULONG)GetString(MSG_BTN_STOP);
         gui->stop_btn = MUI_MakeObjectA(MUIO_Button, params);
     }
     /* Stop button starts disabled */
@@ -392,7 +393,7 @@ int gui_open(struct Gui *gui)
     {
         struct TagItem tags[] = {
             { MUIA_Frame, MUIV_Frame_Text },
-            { MUIA_Text_Contents, (ULONG)"Ready." },
+            { MUIA_Text_Contents, (ULONG)GetString(MSG_STATUS_READY) },
             { MUIA_Text_SetMin, (ULONG)FALSE },
             { TAG_DONE, 0 }
         };
@@ -457,6 +458,8 @@ int gui_open(struct Gui *gui)
                 struct TagItem tags[] = {
                     { MUIA_Window_Title,         (ULONG)PROGRAM_NAME " " VERSION_STRING },
                     { MUIA_Window_ID,            MAKE_ID('M','A','I','N') },
+                    { MUIA_Window_Width,         640 },
+                    { MUIA_Window_Height,        200 },
                     { MUIA_Window_RootObject,    (ULONG)vgrp },
                     { MUIA_Window_DefaultObject, (ULONG)gui->input },
                     { TAG_DONE, 0 }
@@ -486,9 +489,9 @@ int gui_open(struct Gui *gui)
         struct TagItem tags[] = {
             { MUIA_Application_Title,       (ULONG)PROGRAM_NAME },
             { MUIA_Application_Version,     (ULONG)VERSTAG + 1 },
-            { MUIA_Application_Copyright,   (ULONG)"2026" },
-            { MUIA_Application_Author,      (ULONG)"AmigaAI" },
-            { MUIA_Application_Description, (ULONG)"Claude AI Agent for AmigaOS" },
+            { MUIA_Application_Copyright,   (ULONG)"\xa9 2026 Thomas \xd6llinger" },
+            { MUIA_Application_Author,      (ULONG)"Thomas \xd6llinger" },
+            { MUIA_Application_Description, (ULONG)GetString(MSG_APP_DESCRIPTION) },
             { MUIA_Application_Base,        (ULONG)"AMIGAAI" },
             { MUIA_Application_Menustrip,   (ULONG)gui->menustrip },
             { MUIA_Application_Window,      (ULONG)gui->win },
@@ -504,9 +507,9 @@ int gui_open(struct Gui *gui)
         struct TagItem tags[] = {
             { MUIA_Application_Title,       (ULONG)PROGRAM_NAME },
             { MUIA_Application_Version,     (ULONG)VERSTAG + 1 },
-            { MUIA_Application_Copyright,   (ULONG)"2026" },
-            { MUIA_Application_Author,      (ULONG)"AmigaAI" },
-            { MUIA_Application_Description, (ULONG)"Claude AI Agent for AmigaOS" },
+            { MUIA_Application_Copyright,   (ULONG)"\xa9 2026 Thomas \xd6llinger" },
+            { MUIA_Application_Author,      (ULONG)"Thomas \xd6llinger" },
+            { MUIA_Application_Description, (ULONG)GetString(MSG_APP_DESCRIPTION) },
             { MUIA_Application_Base,        (ULONG)"AMIGAAI" },
             { MUIA_Application_Window,      (ULONG)gui->win },
             { TAG_DONE, 0 }
@@ -628,8 +631,8 @@ int gui_open(struct Gui *gui)
     }
 
     /* Welcome message */
-    gui_add_line(gui, "Welcome to " PROGRAM_NAME " " VERSION_STRING);
-    gui_add_line(gui, "Type a message and press Enter or click Send.");
+    gui_add_line(gui, GetString(MSG_WELCOME));
+    gui_add_line(gui, GetString(MSG_WELCOME_HINT));
     gui_add_line(gui, "");
 
     return 0;

--- a/src/locale.c
+++ b/src/locale.c
@@ -1,0 +1,153 @@
+#include "locale.h"
+#include "version.h"
+
+#include <proto/exec.h>
+
+#ifdef __amigaos__
+#include <proto/locale.h>
+#include <libraries/locale.h>
+#else
+/* Cross-compile stub */
+#endif
+
+#ifdef __amigaos__
+struct LocaleBase *LocaleBase = NULL;
+#endif
+static void *catalog = NULL;
+
+static const char * const default_strings[MSG_COUNT] = {
+    /* MSG_MENU_PROJECT       */  "Project",
+    /* MSG_MENU_SETTINGS      */  "Settings",
+    /* MSG_MENU_MEMORY        */  "Memory",
+    /* MSG_MENU_NEW_CHAT      */  "New Chat",
+    /* MSG_MENU_SAVE_CHAT     */  "Save Chat...",
+    /* MSG_MENU_LOAD_CHAT     */  "Load Chat...",
+    /* MSG_MENU_ABOUT         */  "About...",
+    /* MSG_MENU_QUIT          */  "Quit",
+    /* MSG_MENU_APIKEY        */  "API Key...",
+    /* MSG_MENU_MODEL         */  "Model...",
+    /* MSG_MENU_SYSTEM_PROMPT */  "System Prompt...",
+    /* MSG_MENU_VIEW_MEMORY   */  "View Memory...",
+    /* MSG_MENU_ADD_MEMORY    */  "Add Memory...",
+    /* MSG_MENU_CLEAR_MEMORY  */  "Clear Memory",
+    /* MSG_BTN_SEND           */  "_Send",
+    /* MSG_BTN_STOP           */  "S_top",
+    /* MSG_BTN_OK             */  "_OK",
+    /* MSG_BTN_CANCEL         */  "_Cancel",
+    /* MSG_STATUS_READY       */  "Ready.",
+    /* MSG_STATUS_SENDING     */  "Sending to Claude...",
+    /* MSG_STATUS_ABORTED     */  "Request aborted.",
+    /* MSG_STATUS_ERROR       */  "Error",
+    /* MSG_STATUS_CHAT_CLEARED */ "Chat cleared. Ready.",
+    /* MSG_STATUS_TYPE_CMD    */  "Type a command or message",
+    /* MSG_STATUS_EXECUTING   */  "Executing shell command...",
+    /* MSG_STATUS_AREXX_SENDING */ "Sending ARexx command...",
+    /* MSG_STATUS_NO_APIKEY   */  "No API key - configure in Settings",
+    /* MSG_WELCOME            */  "Welcome to " PROGRAM_NAME " " VERSION_STRING,
+    /* MSG_WELCOME_HINT       */  "Type a message and press Enter or click Send.",
+    /* MSG_LABEL_YOU          */  "\033bYou:\033n ",
+    /* MSG_LABEL_CLAUDE       */  "\033bClaude:\033n ",
+    /* MSG_LABEL_ABORTED      */  "\033b\033c--- Aborted ---\033n",
+    /* MSG_LABEL_NEW_CHAT     */  "\033c--- New Chat ---",
+    /* MSG_LABEL_ERROR        */  "\033b\033cERROR:\033n ",
+    /* MSG_STATUS_TOKENS      */  "Tokens: %d in / %d out | Messages: %d",
+    /* MSG_HELP_TITLE         */  "\033b\033cAvailable Commands\033n",
+    /* MSG_HELP_CMD_HELP      */  "\033b/help\033n              - Show this help",
+    /* MSG_HELP_CMD_SHELL     */  "\033b/shell <cmd>\033n      - Run AmigaDOS command",
+    /* MSG_HELP_CMD_AREXX     */  "\033b/arexx <port> <cmd>\033n - Send ARexx command",
+    /* MSG_HELP_CMD_READ      */  "\033b/read <path>\033n      - Read a file",
+    /* MSG_HELP_CMD_WRITE     */  "\033b/write <path> <text>\033n - Write to a file",
+    /* MSG_HELP_CMD_PORTS     */  "\033b/ports\033n            - List public message ports",
+    /* MSG_HELP_CMD_REMEMBER  */  "\033b/remember <text>\033n  - Save a memory entry",
+    /* MSG_HELP_CMD_MEMORY    */  "\033b/memory\033n           - View all memory entries",
+    /* MSG_HELP_FOOTER1       */  "Any other text is sent to Claude as a message.",
+    /* MSG_HELP_FOOTER2       */  "Use cursor up/down to browse input history.",
+    /* MSG_ABOUT_DESCRIPTION  */  "Claude AI Agent for AmigaOS",
+    /* MSG_ABOUT_STACK        */  "Stack: AmiSSL v5, cJSON, MUI",
+    /* MSG_MEM_TITLE_VIEW     */  "Persistent Memory",
+    /* MSG_MEM_TITLE_ADD      */  "Add Memory Entry",
+    /* MSG_MEM_TITLE_CLEAR    */  "Clear Memory",
+    /* MSG_MEM_ENTER_FACT     */  "Enter a fact or preference to remember:",
+    /* MSG_MEM_ADDED          */  "Memory entry added.",
+    /* MSG_MEM_FULL           */  "Memory is full!",
+    /* MSG_MEM_NONE           */  "No memories stored yet.",
+    /* MSG_MEM_NONE_BODY      */  "No memories stored yet.\n\nUse Memory > Add Memory or type:\n/remember <fact>",
+    /* MSG_MEM_CLEAR_CONFIRM  */  "Clear all memory entries?\nThis cannot be undone.",
+    /* MSG_MEM_CLEARED        */  "All memory cleared.",
+    /* MSG_MEM_CLEAR_BUTTONS  */  "*_Clear|_Cancel",
+    /* MSG_MODEL_TITLE        */  "Select Model",
+    /* MSG_MODEL_SET          */  "Model: %s",
+    /* MSG_CHAT_SAVE_TITLE    */  "Save Chat",
+    /* MSG_CHAT_SAVE_NONE     */  "No messages to save.",
+    /* MSG_CHAT_SAVE_FAIL     */  "Failed to serialize chat.",
+    /* MSG_CHAT_SAVE_OK       */  "Chat saved to chat.json",
+    /* MSG_CHAT_SAVE_WRITE_FAIL */ "Failed to save chat!",
+    /* MSG_CHAT_LOAD_NONE     */  "No saved chat found (chat.json).",
+    /* MSG_CHAT_LOAD_TOO_LARGE */ "Chat file too large or empty.",
+    /* MSG_CHAT_LOAD_OOM      */  "Out of memory.",
+    /* MSG_CHAT_LOAD_READ_FAIL */ "Failed to read chat file.",
+    /* MSG_CHAT_LOADED        */  "Chat loaded (%d messages)",
+    /* MSG_CHAT_LOADED_LINE   */  "\033c--- Chat Loaded ---",
+    /* MSG_CHAT_LOAD_PARSE_FAIL */ "Failed to parse saved chat!",
+    /* MSG_ERR_OOM_HISTORY    */  "ERROR: Out of memory clearing history",
+    /* MSG_ERR_UNKNOWN        */  "Unknown error",
+    /* MSG_CMD_SHELL          */  "\033bShell:\033n %s",
+    /* MSG_CMD_AREXX          */  "\033bARexx:\033n %s > %s",
+    /* MSG_CMD_AREXX_USAGE    */  "Usage: /arexx <PORT> <command>",
+    /* MSG_CMD_READ           */  "\033bRead:\033n %s",
+    /* MSG_CMD_WRITE_USAGE    */  "Usage: /write <path> <content>",
+    /* MSG_CMD_DONE           */  "Done",
+    /* MSG_CMD_FAILED         */  "Command failed",
+    /* MSG_CMD_PORTS_TITLE    */  "\033bPublic Ports:\033n",
+    /* MSG_CMD_PORTS_LISTED   */  "Ports listed",
+    /* MSG_CMD_MEM_ENTRIES    */  "Memory: %d entries",
+    /* MSG_WARN_NO_APIKEY     */  "\033bWARNING:\033n No API key configured!",
+    /* MSG_WARN_SET_APIKEY    */  "Use Settings > API Key or set ENV:AmigaAI/api_key",
+    /* MSG_WARN_MEM_LOADED    */  "Memory: %d entries loaded",
+    /* MSG_SYSTEM_COMING_SOON */  "System prompt editor - coming soon",
+    /* MSG_APP_DESCRIPTION    */  "Claude AI Agent for AmigaOS",
+    /* MSG_APIKEY_HINT        */  "Set API key via: echo \"key\" > ENV:AmigaAI/api_key",
+};
+
+const char *GetString(int id)
+{
+    if (id < 0 || id >= MSG_COUNT)
+        return "";
+
+#ifdef __amigaos__
+    if (catalog)
+        return (const char *)GetCatalogStr(
+            (struct Catalog *)catalog, id,
+            (CONST_STRPTR)default_strings[id]);
+#endif
+
+    return default_strings[id];
+}
+
+void locale_open(void)
+{
+#ifdef __amigaos__
+    LocaleBase = (struct LocaleBase *)OpenLibrary((CONST_STRPTR)"locale.library", 38);
+    if (LocaleBase) {
+        struct TagItem tags[] = {
+            { OC_BuiltInLanguage, (ULONG)"english" },
+            { TAG_DONE, 0 }
+        };
+        catalog = OpenCatalogA(NULL, (CONST_STRPTR)"AmigaAI.catalog", tags);
+    }
+#endif
+}
+
+void locale_close(void)
+{
+#ifdef __amigaos__
+    if (catalog) {
+        CloseCatalog((struct Catalog *)catalog);
+        catalog = NULL;
+    }
+    if (LocaleBase) {
+        CloseLibrary((struct Library *)LocaleBase);
+        LocaleBase = NULL;
+    }
+#endif
+}

--- a/src/locale.h
+++ b/src/locale.h
@@ -1,0 +1,144 @@
+#ifndef AMIGAAI_LOCALE_H
+#define AMIGAAI_LOCALE_H
+
+/* String IDs for AmigaAI localization */
+
+/* Menu titles */
+#define MSG_MENU_PROJECT           0
+#define MSG_MENU_SETTINGS          1
+#define MSG_MENU_MEMORY            2
+
+/* Menu items - Project */
+#define MSG_MENU_NEW_CHAT          3
+#define MSG_MENU_SAVE_CHAT         4
+#define MSG_MENU_LOAD_CHAT         5
+#define MSG_MENU_ABOUT             6
+#define MSG_MENU_QUIT              7
+
+/* Menu items - Settings */
+#define MSG_MENU_APIKEY            8
+#define MSG_MENU_MODEL             9
+#define MSG_MENU_SYSTEM_PROMPT     10
+
+/* Menu items - Memory */
+#define MSG_MENU_VIEW_MEMORY       11
+#define MSG_MENU_ADD_MEMORY        12
+#define MSG_MENU_CLEAR_MEMORY      13
+
+/* Buttons */
+#define MSG_BTN_SEND               14
+#define MSG_BTN_STOP               15
+#define MSG_BTN_OK                 16
+#define MSG_BTN_CANCEL             17
+
+/* Status bar */
+#define MSG_STATUS_READY           18
+#define MSG_STATUS_SENDING         19
+#define MSG_STATUS_ABORTED         20
+#define MSG_STATUS_ERROR           21
+#define MSG_STATUS_CHAT_CLEARED    22
+#define MSG_STATUS_TYPE_CMD        23
+#define MSG_STATUS_EXECUTING       24
+#define MSG_STATUS_AREXX_SENDING   25
+#define MSG_STATUS_NO_APIKEY       26
+
+/* Welcome */
+#define MSG_WELCOME                27
+#define MSG_WELCOME_HINT           28
+
+/* Labels */
+#define MSG_LABEL_YOU              29
+#define MSG_LABEL_CLAUDE           30
+#define MSG_LABEL_ABORTED          31
+#define MSG_LABEL_NEW_CHAT         32
+#define MSG_LABEL_ERROR            33
+
+/* Token status */
+#define MSG_STATUS_TOKENS          34
+
+/* Help text */
+#define MSG_HELP_TITLE             35
+#define MSG_HELP_CMD_HELP          36
+#define MSG_HELP_CMD_SHELL         37
+#define MSG_HELP_CMD_AREXX         38
+#define MSG_HELP_CMD_READ          39
+#define MSG_HELP_CMD_WRITE         40
+#define MSG_HELP_CMD_PORTS         41
+#define MSG_HELP_CMD_REMEMBER      42
+#define MSG_HELP_CMD_MEMORY        43
+#define MSG_HELP_FOOTER1           44
+#define MSG_HELP_FOOTER2           45
+
+/* About dialog */
+#define MSG_ABOUT_DESCRIPTION      46
+#define MSG_ABOUT_STACK            47
+
+/* Memory dialogs */
+#define MSG_MEM_TITLE_VIEW         48
+#define MSG_MEM_TITLE_ADD          49
+#define MSG_MEM_TITLE_CLEAR        50
+#define MSG_MEM_ENTER_FACT         51
+#define MSG_MEM_ADDED              52
+#define MSG_MEM_FULL               53
+#define MSG_MEM_NONE               54
+#define MSG_MEM_NONE_BODY          55
+#define MSG_MEM_CLEAR_CONFIRM      56
+#define MSG_MEM_CLEARED            57
+#define MSG_MEM_CLEAR_BUTTONS      58
+
+/* Model dialog */
+#define MSG_MODEL_TITLE            59
+#define MSG_MODEL_SET              60
+
+/* Chat save/load */
+#define MSG_CHAT_SAVE_TITLE        61
+#define MSG_CHAT_SAVE_NONE         62
+#define MSG_CHAT_SAVE_FAIL         63
+#define MSG_CHAT_SAVE_OK           64
+#define MSG_CHAT_SAVE_WRITE_FAIL   65
+#define MSG_CHAT_LOAD_NONE         66
+#define MSG_CHAT_LOAD_TOO_LARGE    67
+#define MSG_CHAT_LOAD_OOM          68
+#define MSG_CHAT_LOAD_READ_FAIL    69
+#define MSG_CHAT_LOADED            70
+#define MSG_CHAT_LOADED_LINE       71
+#define MSG_CHAT_LOAD_PARSE_FAIL   72
+
+/* Errors */
+#define MSG_ERR_OOM_HISTORY        73
+#define MSG_ERR_UNKNOWN            74
+
+/* Slash command feedback */
+#define MSG_CMD_SHELL              75
+#define MSG_CMD_AREXX              76
+#define MSG_CMD_AREXX_USAGE        77
+#define MSG_CMD_READ               78
+#define MSG_CMD_WRITE_USAGE        79
+#define MSG_CMD_DONE               80
+#define MSG_CMD_FAILED             81
+#define MSG_CMD_PORTS_TITLE        82
+#define MSG_CMD_PORTS_LISTED       83
+#define MSG_CMD_MEM_ENTRIES        84
+
+/* Startup warnings */
+#define MSG_WARN_NO_APIKEY         85
+#define MSG_WARN_SET_APIKEY        86
+#define MSG_WARN_MEM_LOADED        87
+
+/* System prompt editor */
+#define MSG_SYSTEM_COMING_SOON     88
+
+/* Application description */
+#define MSG_APP_DESCRIPTION        89
+
+/* API key hint */
+#define MSG_APIKEY_HINT            90
+
+#define MSG_COUNT                  91
+
+/* Locale functions */
+void locale_open(void);
+void locale_close(void);
+const char *GetString(int id);
+
+#endif /* AMIGAAI_LOCALE_H */

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,7 @@
 #include "http.h"
 #include "claude.h"
 #include "gui.h"
+#include "locale.h"
 #include "arexx_port.h"
 #include "memory.h"
 #include "tools.h"
@@ -354,26 +355,26 @@ static void handle_send(void)
 
     /* /help - list all available commands */
     if (strcasecmp(input, "/help") == 0) {
-        gui_add_line(&app_gui, "\033b\033cAvailable Commands\033n");
+        gui_add_line(&app_gui, GetString(MSG_HELP_TITLE));
         gui_add_line(&app_gui, "");
-        gui_add_line(&app_gui, "\033b/help\033n              - Show this help");
-        gui_add_line(&app_gui, "\033b/shell <cmd>\033n      - Run AmigaDOS command");
+        gui_add_line(&app_gui, GetString(MSG_HELP_CMD_HELP));
+        gui_add_line(&app_gui, GetString(MSG_HELP_CMD_SHELL));
         gui_add_line(&app_gui, "  Example: /shell list SYS:Utilities");
-        gui_add_line(&app_gui, "\033b/arexx <port> <cmd>\033n - Send ARexx command");
+        gui_add_line(&app_gui, GetString(MSG_HELP_CMD_AREXX));
         gui_add_line(&app_gui, "  Example: /arexx MULTIVIEW ABOUT");
-        gui_add_line(&app_gui, "\033b/read <path>\033n      - Read a file");
+        gui_add_line(&app_gui, GetString(MSG_HELP_CMD_READ));
         gui_add_line(&app_gui, "  Example: /read S:Startup-Sequence");
-        gui_add_line(&app_gui, "\033b/write <path> <text>\033n - Write to a file");
+        gui_add_line(&app_gui, GetString(MSG_HELP_CMD_WRITE));
         gui_add_line(&app_gui, "  Example: /write RAM:test.txt Hello World");
-        gui_add_line(&app_gui, "\033b/ports\033n            - List public message ports");
-        gui_add_line(&app_gui, "\033b/remember <text>\033n  - Save a memory entry");
+        gui_add_line(&app_gui, GetString(MSG_HELP_CMD_PORTS));
+        gui_add_line(&app_gui, GetString(MSG_HELP_CMD_REMEMBER));
         gui_add_line(&app_gui, "  Example: /remember I prefer 68030 mode");
-        gui_add_line(&app_gui, "\033b/memory\033n           - View all memory entries");
+        gui_add_line(&app_gui, GetString(MSG_HELP_CMD_MEMORY));
         gui_add_line(&app_gui, "");
-        gui_add_line(&app_gui, "Any other text is sent to Claude as a message.");
-        gui_add_line(&app_gui, "Use cursor up/down to browse input history.");
+        gui_add_line(&app_gui, GetString(MSG_HELP_FOOTER1));
+        gui_add_line(&app_gui, GetString(MSG_HELP_FOOTER2));
         gui_add_line(&app_gui, "");
-        gui_set_status(&app_gui, "Type a command or message");
+        gui_set_status(&app_gui, GetString(MSG_STATUS_TYPE_CMD));
         gui_clear_input(&app_gui);
         return;
     }
@@ -385,14 +386,14 @@ static void handle_send(void)
         if (*entry) {
             if (memory_add(&app_memory, entry) == 0) {
                 memory_save(&app_memory);
-                gui_add_line(&app_gui, "\033bMemory:\033n Entry saved.");
+                gui_add_line(&app_gui, GetString(MSG_MEM_ADDED));
                 {
                     char buf[64];
-                    snprintf(buf, sizeof(buf), "Memory: %d entries", app_memory.count);
+                    snprintf(buf, sizeof(buf), GetString(MSG_CMD_MEM_ENTRIES), app_memory.count);
                     gui_set_status(&app_gui, buf);
                 }
             } else {
-                gui_add_line(&app_gui, "\033bMemory:\033n Memory is full!");
+                gui_add_line(&app_gui, GetString(MSG_MEM_FULL));
             }
         }
         gui_clear_input(&app_gui);
@@ -410,13 +411,13 @@ static void handle_send(void)
     if (strcasecmp(input, "/ports") == 0) {
         int is_error = 0;
         char *result = tool_execute("list_ports", NULL, &is_error);
-        gui_add_line(&app_gui, "\033bPublic Ports:\033n");
+        gui_add_line(&app_gui, GetString(MSG_CMD_PORTS_TITLE));
         if (result) {
             gui_add_text(&app_gui, NULL, result);
             free(result);
         }
         gui_add_line(&app_gui, "");
-        gui_set_status(&app_gui, "Ports listed");
+        gui_set_status(&app_gui, GetString(MSG_CMD_PORTS_LISTED));
         gui_clear_input(&app_gui);
         return;
     }
@@ -432,9 +433,9 @@ static void handle_send(void)
             char line[256];
 
             cJSON_AddStringToObject(inp, "command", cmd);
-            snprintf(line, sizeof(line), "\033bShell:\033n %s", cmd);
+            snprintf(line, sizeof(line), GetString(MSG_CMD_SHELL), cmd);
             gui_add_line(&app_gui, line);
-            gui_set_status(&app_gui, "Executing shell command...");
+            gui_set_status(&app_gui, GetString(MSG_STATUS_EXECUTING));
 
             result = tool_execute("shell_command", inp, &is_error);
             cJSON_Delete(inp);
@@ -445,7 +446,7 @@ static void handle_send(void)
                 free(result);
             }
             gui_add_line(&app_gui, "");
-            gui_set_status(&app_gui, is_error ? "Command failed" : "Done");
+            gui_set_status(&app_gui, is_error ? GetString(MSG_CMD_FAILED) : GetString(MSG_CMD_DONE));
         }
         gui_clear_input(&app_gui);
         return;
@@ -465,7 +466,7 @@ static void handle_send(void)
             char line[256];
 
             if (!sp) {
-                gui_add_line(&app_gui, "Usage: /arexx <PORT> <command>");
+                gui_add_line(&app_gui, GetString(MSG_CMD_AREXX_USAGE));
                 gui_clear_input(&app_gui);
                 return;
             }
@@ -482,9 +483,9 @@ static void handle_send(void)
             cJSON_AddStringToObject(inp, "port", port);
             cJSON_AddStringToObject(inp, "command", cmd);
 
-            snprintf(line, sizeof(line), "\033bARexx:\033n %s > %s", port, cmd);
+            snprintf(line, sizeof(line), GetString(MSG_CMD_AREXX), port, cmd);
             gui_add_line(&app_gui, line);
-            gui_set_status(&app_gui, "Sending ARexx command...");
+            gui_set_status(&app_gui, GetString(MSG_STATUS_AREXX_SENDING));
 
             result = tool_execute("arexx_command", inp, &is_error);
             cJSON_Delete(inp);
@@ -495,7 +496,7 @@ static void handle_send(void)
                 free(result);
             }
             gui_add_line(&app_gui, "");
-            gui_set_status(&app_gui, is_error ? "ARexx failed" : "Done");
+            gui_set_status(&app_gui, is_error ? GetString(MSG_CMD_FAILED) : GetString(MSG_CMD_DONE));
         }
         gui_clear_input(&app_gui);
         return;
@@ -512,7 +513,7 @@ static void handle_send(void)
             char line[256];
 
             cJSON_AddStringToObject(inp, "path", path);
-            snprintf(line, sizeof(line), "\033bRead:\033n %s", path);
+            snprintf(line, sizeof(line), GetString(MSG_CMD_READ), path);
             gui_add_line(&app_gui, line);
 
             result = tool_execute("read_file", inp, &is_error);
@@ -524,7 +525,7 @@ static void handle_send(void)
                 free(result);
             }
             gui_add_line(&app_gui, "");
-            gui_set_status(&app_gui, is_error ? "Read failed" : "Done");
+            gui_set_status(&app_gui, is_error ? GetString(MSG_CMD_FAILED) : GetString(MSG_CMD_DONE));
         }
         gui_clear_input(&app_gui);
         return;
@@ -542,7 +543,7 @@ static void handle_send(void)
             char *result;
 
             if (!sp) {
-                gui_add_line(&app_gui, "Usage: /write <path> <content>");
+                gui_add_line(&app_gui, GetString(MSG_CMD_WRITE_USAGE));
                 gui_clear_input(&app_gui);
                 return;
             }
@@ -565,7 +566,7 @@ static void handle_send(void)
                 free(result);
             }
             gui_add_line(&app_gui, "");
-            gui_set_status(&app_gui, is_error ? "Write failed" : "Done");
+            gui_set_status(&app_gui, is_error ? GetString(MSG_CMD_FAILED) : GetString(MSG_CMD_DONE));
         }
         gui_clear_input(&app_gui);
         return;
@@ -581,12 +582,12 @@ static void handle_send(void)
         input_copy[sizeof(input_copy) - 1] = '\0';
 
         /* Display user message */
-        gui_add_text(&app_gui, "\033bYou:\033n ", input_copy);
+        gui_add_text(&app_gui, GetString(MSG_LABEL_YOU), input_copy);
         chat_log("USER", input_copy);
 
         /* Clear input and set busy */
         gui_clear_input(&app_gui);
-        gui_set_status(&app_gui, "Sending to Claude...");
+        gui_set_status(&app_gui, GetString(MSG_STATUS_SENDING));
         gui_set_busy(&app_gui, 1);
 
         /* Send to API */
@@ -597,20 +598,20 @@ static void handle_send(void)
 
     if (app_gui.abort_requested) {
         /* User clicked Stop */
-        gui_add_line(&app_gui, "\033b\033c--- Aborted ---\033n");
-        gui_set_status(&app_gui, "Request aborted.");
+        gui_add_line(&app_gui, GetString(MSG_LABEL_ABORTED));
+        gui_set_status(&app_gui, GetString(MSG_STATUS_ABORTED));
         chat_log("SYSTEM", "Request aborted by user");
         free(reply);
         free(error_msg);
     } else if (reply) {
         /* Display response */
-        gui_add_text(&app_gui, "\033bClaude:\033n ", reply);
+        gui_add_text(&app_gui, GetString(MSG_LABEL_CLAUDE), reply);
         gui_add_line(&app_gui, "");
         chat_log("CLAUDE", reply);
 
         /* Show token usage in status bar */
         snprintf(status_buf, sizeof(status_buf),
-                 "Tokens: %d in / %d out | Messages: %d",
+                 GetString(MSG_STATUS_TOKENS),
                  app_claude.last_input_tokens,
                  app_claude.last_output_tokens,
                  claude_message_count(&app_claude));
@@ -620,10 +621,11 @@ static void handle_send(void)
     } else {
         /* Display error */
         char err_buf[256];
-        snprintf(err_buf, sizeof(err_buf), "\033b\033cERROR:\033n %s",
-                 error_msg ? error_msg : "Unknown error");
+        snprintf(err_buf, sizeof(err_buf), "%s%s",
+                 GetString(MSG_LABEL_ERROR),
+                 error_msg ? error_msg : GetString(MSG_ERR_UNKNOWN));
         gui_add_line(&app_gui, err_buf);
-        gui_set_status(&app_gui, error_msg ? error_msg : "Error");
+        gui_set_status(&app_gui, error_msg ? error_msg : GetString(MSG_STATUS_ERROR));
         chat_log("ERROR", error_msg ? error_msg : "Unknown error");
         free(error_msg);
     }
@@ -632,24 +634,24 @@ static void handle_send(void)
 static void handle_new_chat(void)
 {
     if (claude_clear_history(&app_claude) != 0) {
-        gui_set_status(&app_gui, "ERROR: Out of memory clearing history");
+        gui_set_status(&app_gui, GetString(MSG_ERR_OOM_HISTORY));
         return;
     }
     gui_clear_chat(&app_gui);
-    gui_add_line(&app_gui, "\033c--- New Chat ---");
+    gui_add_line(&app_gui, GetString(MSG_LABEL_NEW_CHAT));
     gui_add_line(&app_gui, "");
-    gui_set_status(&app_gui, "Chat cleared. Ready.");
+    gui_set_status(&app_gui, GetString(MSG_STATUS_CHAT_CLEARED));
 }
 
 static void handle_about(void)
 {
-    gui_about(&app_gui,
-              PROGRAM_NAME,
-              PROGRAM_NAME " " VERSION_STRING "\n\n"
-              "Claude AI Agent for AmigaOS\n\n"
-              "Stack: AmiSSL v5, cJSON, MUI\n"
-              "ARexx Port: AMIGAAI\n\n"
-              "Commands: /remember, /memory");
+    char buf[512];
+    snprintf(buf, sizeof(buf),
+             "%s %s\n\n%s\n\n\xa9 2026 Thomas \xd6llinger\n\n%s\nARexx Port: AMIGAAI",
+             PROGRAM_NAME, VERSION_STRING,
+             GetString(MSG_ABOUT_DESCRIPTION),
+             GetString(MSG_ABOUT_STACK));
+    gui_about(&app_gui, PROGRAM_NAME, buf);
 }
 
 /* Safe non-variadic wrappers for MUI attribute access.
@@ -676,14 +678,196 @@ static void handle_memory_view(void)
 {
     char *memstr = memory_to_string(&app_memory);
     if (memstr) {
-        gui_about(&app_gui, "Persistent Memory", memstr);
+        gui_about(&app_gui, GetString(MSG_MEM_TITLE_VIEW), memstr);
         free(memstr);
     } else {
-        gui_about(&app_gui, "Persistent Memory",
-                  "No memories stored yet.\n\n"
-                  "Use Memory > Add Memory or type:\n"
-                  "/remember <fact>");
+        gui_about(&app_gui, GetString(MSG_MEM_TITLE_VIEW),
+                  GetString(MSG_MEM_NONE_BODY));
     }
+}
+
+static const char *model_list[] = {
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+    "claude-opus-4-6",
+    NULL
+};
+
+static void handle_model_select(void)
+{
+    Object *win, *list, *ok_btn, *cancel_btn;
+    Object *hgrp, *vgrp;
+    ULONG open;
+    ULONG sigs;
+    int done = 0;
+    int i, active = 0;
+    struct IClass *wincl;
+
+    /* Find currently active model in list */
+    for (i = 0; model_list[i]; i++) {
+        if (strcmp(model_list[i], app_config.model) == 0) {
+            active = i;
+            break;
+        }
+    }
+
+    {
+        ULONG ok_params[1];
+        ok_params[0] = (ULONG)GetString(MSG_BTN_OK);
+        ok_btn = MUI_MakeObjectA(MUIO_Button, ok_params);
+    }
+    {
+        ULONG cancel_params[1];
+        cancel_params[0] = (ULONG)GetString(MSG_BTN_CANCEL);
+        cancel_btn = MUI_MakeObjectA(MUIO_Button, cancel_params);
+    }
+    if (!ok_btn || !cancel_btn) return;
+
+    /* Create List with model entries */
+    {
+        struct TagItem tags[] = {
+            { MUIA_Frame, MUIV_Frame_InputList },
+            { MUIA_List_ConstructHook, MUIV_List_ConstructHook_String },
+            { MUIA_List_DestructHook,  MUIV_List_DestructHook_String },
+            { MUIA_List_SourceArray, (ULONG)model_list },
+            { MUIA_CycleChain, (ULONG)TRUE },
+            { TAG_DONE, 0 }
+        };
+        list = MUI_NewObjectA((CONST_STRPTR)MUIC_List, tags);
+    }
+
+    if (!list) return;
+
+    /* Pre-select active model */
+    xset(list, MUIA_List_Active, (ULONG)active);
+
+    {
+        struct TagItem tags[] = {
+            { MUIA_Group_Horiz, TRUE },
+            { MUIA_Group_Child, (ULONG)ok_btn },
+            { MUIA_Group_Child, (ULONG)cancel_btn },
+            { TAG_DONE, 0 }
+        };
+        hgrp = MUI_NewObjectA((CONST_STRPTR)MUIC_Group, tags);
+    }
+
+    {
+        struct TagItem tags[] = {
+            { MUIA_Group_Child, (ULONG)list },
+            { MUIA_Group_Child, (ULONG)hgrp },
+            { TAG_DONE, 0 }
+        };
+        vgrp = MUI_NewObjectA((CONST_STRPTR)MUIC_Group, tags);
+    }
+
+    if (!vgrp) return;
+
+    wincl = MUI_GetClass((CONST_STRPTR)MUIC_Window);
+    if (!wincl) {
+        MUI_DisposeObject(vgrp);
+        return;
+    }
+    {
+        struct TagItem tags[] = {
+            { MUIA_Window_Title, (ULONG)GetString(MSG_MODEL_TITLE) },
+            { MUIA_Window_ID,    MAKE_ID('M','O','D','L') },
+            { MUIA_Window_RootObject, (ULONG)vgrp },
+            { TAG_DONE, 0 }
+        };
+        win = NewObjectA(wincl, NULL, tags);
+    }
+    MUI_FreeClass(wincl);
+
+    if (!win) return;
+
+    {
+        ULONG msg[] = { OM_ADDMEMBER, (ULONG)win };
+        DoMethodA(app_gui.app, (Msg)msg);
+    }
+
+    /* OK button */
+    {
+        ULONG msg[] = { MUIM_Notify, MUIA_Pressed, (ULONG)FALSE,
+                         (ULONG)app_gui.app, 2,
+                         MUIM_Application_ReturnID, 100 };
+        DoMethodA(ok_btn, (Msg)msg);
+    }
+    /* Double-click on list entry = OK */
+    {
+        ULONG msg[] = { MUIM_Notify, MUIA_Listview_DoubleClick, (ULONG)TRUE,
+                         (ULONG)app_gui.app, 2,
+                         MUIM_Application_ReturnID, 100 };
+        DoMethodA(list, (Msg)msg);
+    }
+    /* Cancel button */
+    {
+        ULONG msg[] = { MUIM_Notify, MUIA_Pressed, (ULONG)FALSE,
+                         (ULONG)app_gui.app, 2,
+                         MUIM_Application_ReturnID, 101 };
+        DoMethodA(cancel_btn, (Msg)msg);
+    }
+    /* Window close = Cancel */
+    {
+        ULONG msg[] = { MUIM_Notify, MUIA_Window_CloseRequest, (ULONG)TRUE,
+                         (ULONG)app_gui.app, 2,
+                         MUIM_Application_ReturnID, 101 };
+        DoMethodA(win, (Msg)msg);
+    }
+
+    xset(win, MUIA_Window_Open, (ULONG)TRUE);
+    open = xget(win, MUIA_Window_Open);
+    if (!open) {
+        ULONG msg[] = { OM_REMMEMBER, (ULONG)win };
+        DoMethodA(app_gui.app, (Msg)msg);
+        MUI_DisposeObject(win);
+        return;
+    }
+
+    while (!done) {
+        ULONG mid;
+        {
+            ULONG msg[] = { MUIM_Application_NewInput, (ULONG)&sigs };
+            mid = DoMethodA(app_gui.app, (Msg)msg);
+        }
+        switch (mid) {
+        case 100: /* OK / Double-click */
+        {
+            LONG sel = (LONG)xget(list, MUIA_List_Active);
+            if (sel >= 0) {
+                char *entry = NULL;
+                {
+                    ULONG msg[] = { MUIM_List_GetEntry, (ULONG)sel, (ULONG)&entry };
+                    DoMethodA(list, (Msg)msg);
+                }
+                if (entry) {
+                    char buf[128];
+                    strncpy(app_config.model, entry, CONFIG_MAX_MODEL_LEN - 1);
+                    app_config.model[CONFIG_MAX_MODEL_LEN - 1] = '\0';
+                    config_save(&app_config, 1);
+                    snprintf(buf, sizeof(buf), GetString(MSG_MODEL_SET), app_config.model);
+                    gui_set_status(&app_gui, buf);
+                }
+            }
+            done = 1;
+            break;
+        }
+        case 101: /* Cancel / Close */
+            done = 1;
+            break;
+        case MUIV_Application_ReturnID_Quit:
+            done = 1;
+            break;
+        }
+        if (sigs && !done)
+            sigs = Wait(sigs);
+    }
+
+    xset(win, MUIA_Window_Open, FALSE);
+    {
+        ULONG msg[] = { OM_REMMEMBER, (ULONG)win };
+        DoMethodA(app_gui.app, (Msg)msg);
+    }
+    MUI_DisposeObject(win);
 }
 
 static void handle_memory_add(void)
@@ -698,12 +882,12 @@ static void handle_memory_add(void)
     /* Create buttons via MUI_MakeObjectA (non-variadic) */
     {
         ULONG ok_params[1];
-        ok_params[0] = (ULONG)"_OK";
+        ok_params[0] = (ULONG)GetString(MSG_BTN_OK);
         ok_btn = MUI_MakeObjectA(MUIO_Button, ok_params);
     }
     {
         ULONG cancel_params[1];
-        cancel_params[0] = (ULONG)"_Cancel";
+        cancel_params[0] = (ULONG)GetString(MSG_BTN_CANCEL);
         cancel_btn = MUI_MakeObjectA(MUIO_Button, cancel_params);
     }
     if (!ok_btn || !cancel_btn) return;
@@ -711,7 +895,7 @@ static void handle_memory_add(void)
     /* Create text label */
     {
         struct TagItem tags[] = {
-            { MUIA_Text_Contents, (ULONG)"Enter a fact or preference to remember:" },
+            { MUIA_Text_Contents, (ULONG)GetString(MSG_MEM_ENTER_FACT) },
             { TAG_DONE, 0 }
         };
         text_obj = MUI_NewObjectA((CONST_STRPTR)MUIC_Text, tags);
@@ -760,7 +944,7 @@ static void handle_memory_add(void)
     }
     {
         struct TagItem tags[] = {
-            { MUIA_Window_Title, (ULONG)"Add Memory Entry" },
+            { MUIA_Window_Title, (ULONG)GetString(MSG_MEM_TITLE_ADD) },
             { MUIA_Window_ID,    MAKE_ID('M','E','M','A') },
             { MUIA_Window_RootObject, (ULONG)vgrp },
             { TAG_DONE, 0 }
@@ -828,9 +1012,9 @@ static void handle_memory_add(void)
             if (text && text[0]) {
                 if (memory_add(&app_memory, text) == 0) {
                     memory_save(&app_memory);
-                    gui_set_status(&app_gui, "Memory entry added.");
+                    gui_set_status(&app_gui, GetString(MSG_MEM_ADDED));
                 } else {
-                    gui_set_status(&app_gui, "Memory is full!");
+                    gui_set_status(&app_gui, GetString(MSG_MEM_FULL));
                 }
             }
             done = 1;
@@ -860,20 +1044,19 @@ static void handle_memory_clear(void)
     LONG result;
 
     if (app_memory.count == 0) {
-        gui_about(&app_gui, "Clear Memory", "No memories to clear.");
+        gui_about(&app_gui, GetString(MSG_MEM_TITLE_CLEAR), GetString(MSG_MEM_NONE));
         return;
     }
 
     result = MUI_RequestA(app_gui.app, app_gui.win, 0,
-                          (CONST_STRPTR)"Clear Memory",
-                          (CONST_STRPTR)"*_Clear|_Cancel",
-                          (CONST_STRPTR)"Clear all memory entries?\n"
-                                        "This cannot be undone.",
+                          (CONST_STRPTR)GetString(MSG_MEM_TITLE_CLEAR),
+                          (CONST_STRPTR)GetString(MSG_MEM_CLEAR_BUTTONS),
+                          (CONST_STRPTR)GetString(MSG_MEM_CLEAR_CONFIRM),
                           NULL);
     if (result == 1) {
         memory_clear(&app_memory);
         memory_save(&app_memory);
-        gui_set_status(&app_gui, "All memory cleared.");
+        gui_set_status(&app_gui, GetString(MSG_MEM_CLEARED));
     }
 }
 
@@ -886,13 +1069,13 @@ static void handle_chat_save(void)
     const char *filename = "AmigaAI:chat.json";
 
     if (claude_message_count(&app_claude) == 0) {
-        gui_about(&app_gui, "Save Chat", "No messages to save.");
+        gui_about(&app_gui, GetString(MSG_CHAT_SAVE_TITLE), GetString(MSG_CHAT_SAVE_NONE));
         return;
     }
 
     json_str = cJSON_Print(app_claude.messages);
     if (!json_str) {
-        gui_set_status(&app_gui, "Failed to serialize chat.");
+        gui_set_status(&app_gui, GetString(MSG_CHAT_SAVE_FAIL));
         return;
     }
 
@@ -900,9 +1083,9 @@ static void handle_chat_save(void)
     if (f) {
         fputs(json_str, f);
         fclose(f);
-        gui_set_status(&app_gui, "Chat saved to chat.json");
+        gui_set_status(&app_gui, GetString(MSG_CHAT_SAVE_OK));
     } else {
-        gui_set_status(&app_gui, "Failed to save chat!");
+        gui_set_status(&app_gui, GetString(MSG_CHAT_SAVE_WRITE_FAIL));
     }
     cJSON_free(json_str);
 }
@@ -917,7 +1100,7 @@ static void handle_chat_load(void)
 
     f = fopen(filename, "r");
     if (!f) {
-        gui_set_status(&app_gui, "No saved chat found (chat.json).");
+        gui_set_status(&app_gui, GetString(MSG_CHAT_LOAD_NONE));
         return;
     }
 
@@ -927,21 +1110,21 @@ static void handle_chat_load(void)
 
     if (len <= 0 || len > 256L * 1024L) {
         fclose(f);
-        gui_set_status(&app_gui, "Chat file too large or empty.");
+        gui_set_status(&app_gui, GetString(MSG_CHAT_LOAD_TOO_LARGE));
         return;
     }
 
     buf = malloc(len + 1);
     if (!buf) {
         fclose(f);
-        gui_set_status(&app_gui, "Out of memory.");
+        gui_set_status(&app_gui, GetString(MSG_CHAT_LOAD_OOM));
         return;
     }
 
     if ((long)fread(buf, 1, len, f) != len) {
         free(buf);
         fclose(f);
-        gui_set_status(&app_gui, "Failed to read chat file.");
+        gui_set_status(&app_gui, GetString(MSG_CHAT_LOAD_READ_FAIL));
         return;
     }
     buf[len] = '\0';
@@ -957,7 +1140,7 @@ static void handle_chat_load(void)
 
         /* Rebuild the chat display */
         gui_clear_chat(&app_gui);
-        gui_add_line(&app_gui, "\033c--- Chat Loaded ---");
+        gui_add_line(&app_gui, GetString(MSG_CHAT_LOADED_LINE));
         gui_add_line(&app_gui, "");
 
         /* Replay messages into display */
@@ -971,10 +1154,10 @@ static void handle_chat_load(void)
                     cJSON_IsString(role) && cJSON_IsString(content))
                 {
                     if (strcmp(role->valuestring, "user") == 0)
-                        gui_add_text(&app_gui, "\033bYou:\033n ",
+                        gui_add_text(&app_gui, GetString(MSG_LABEL_YOU),
                                      content->valuestring);
                     else
-                        gui_add_text(&app_gui, "\033bClaude:\033n ",
+                        gui_add_text(&app_gui, GetString(MSG_LABEL_CLAUDE),
                                      content->valuestring);
                     gui_add_line(&app_gui, "");
                 }
@@ -983,13 +1166,13 @@ static void handle_chat_load(void)
 
         {
             char buf2[64];
-            snprintf(buf2, sizeof(buf2), "Chat loaded (%d messages)",
+            snprintf(buf2, sizeof(buf2), GetString(MSG_CHAT_LOADED),
                      claude_message_count(&app_claude));
             gui_set_status(&app_gui, buf2);
         }
     } else {
         if (loaded) cJSON_Delete(loaded);
-        gui_set_status(&app_gui, "Failed to parse saved chat!");
+        gui_set_status(&app_gui, GetString(MSG_CHAT_LOAD_PARSE_FAIL));
     }
 }
 
@@ -1127,6 +1310,9 @@ int main(int argc, char *argv[])
     }
     dbg_step(2, "Libraries OK");
 
+    /* Initialize locale for translations */
+    locale_open();
+
     /* Initialize HTTP/SSL subsystem */
     dbg_step(3, "Init HTTP/SSL...");
     if (http_init() != 0) {
@@ -1209,16 +1395,16 @@ int main(int argc, char *argv[])
 
     /* Check for missing API key */
     if (!app_config.api_key[0]) {
-        gui_add_line(&app_gui, "\033bWARNING:\033n No API key configured!");
-        gui_add_line(&app_gui, "Use Settings > API Key or set ENV:AmigaAI/api_key");
+        gui_add_line(&app_gui, GetString(MSG_WARN_NO_APIKEY));
+        gui_add_line(&app_gui, GetString(MSG_WARN_SET_APIKEY));
         gui_add_line(&app_gui, "");
-        gui_set_status(&app_gui, "No API key - configure in Settings");
+        gui_set_status(&app_gui, GetString(MSG_STATUS_NO_APIKEY));
     }
 
     /* Show memory count on startup */
     if (app_memory.count > 0) {
         char mbuf[64];
-        snprintf(mbuf, sizeof(mbuf), "Memory: %d entries loaded", app_memory.count);
+        snprintf(mbuf, sizeof(mbuf), GetString(MSG_WARN_MEM_LOADED), app_memory.count);
         gui_add_line(&app_gui, mbuf);
         gui_add_line(&app_gui, "");
     }
@@ -1246,21 +1432,16 @@ int main(int argc, char *argv[])
 
         case GUI_ID_APIKEY:
             /* TODO: Open API key requester */
-            gui_set_status(&app_gui, "Set API key via: echo \"key\" > ENV:AmigaAI/api_key");
+            gui_set_status(&app_gui, GetString(MSG_APIKEY_HINT));
             break;
 
         case GUI_ID_MODEL:
-            /* TODO: Open model selection requester */
-            {
-                char buf[128];
-                snprintf(buf, sizeof(buf), "Current model: %s", app_config.model);
-                gui_set_status(&app_gui, buf);
-            }
+            handle_model_select();
             break;
 
         case GUI_ID_SYSTEM:
             /* TODO: Open system prompt editor */
-            gui_set_status(&app_gui, "System prompt editor - coming soon");
+            gui_set_status(&app_gui, GetString(MSG_SYSTEM_COMING_SOON));
             break;
 
         /* Memory menu */
@@ -1315,6 +1496,7 @@ int main(int argc, char *argv[])
     gui_close(&app_gui);
     claude_cleanup(&app_claude);
     http_cleanup();
+    locale_close();
     close_libraries();
     cleanup_search_path();
 

--- a/tools/mkcatalog.c
+++ b/tools/mkcatalog.c
@@ -1,0 +1,222 @@
+/*
+ * mkcatalog - Build AmigaOS .catalog files from text translations
+ *
+ * Reads a simple text file with ID/string pairs and produces
+ * an IFF CTLG binary catalog file for AmigaOS locale.library.
+ *
+ * Input format:
+ *   ; comment
+ *   <id number>
+ *   <translated string>
+ *
+ * Escape sequences in strings:
+ *   \xNN  - hex byte (e.g. \xe4 for ä in Latin-1)
+ *   \n    - newline
+ *   \033  - ESC (0x1B, for MUI formatting)
+ *
+ * Usage: mkcatalog <input.txt> <output.catalog> <language> [version]
+ *
+ * IFF CTLG format:
+ *   FORM .... CTLG
+ *     CSET ....   (code set chunk - 4 bytes, usually 0 for ISO-8859-1)
+ *     FVER ....   (version string)
+ *     STRS ....   (string data: pairs of [4-byte ID][NUL-terminated string][pad])
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_STRINGS 256
+#define MAX_STR_LEN 512
+
+struct CatEntry {
+    int id;
+    char str[MAX_STR_LEN];
+};
+
+/* Parse escape sequences in a string, modifying it in place.
+ * Returns the new length. */
+static int parse_escapes(char *s)
+{
+    char *r = s, *w = s;
+    while (*r) {
+        if (*r == '\\') {
+            r++;
+            if (*r == 'n') {
+                *w++ = '\n';
+                r++;
+            } else if (*r == '0' && r[1] == '3' && r[2] == '3') {
+                *w++ = '\033';
+                r += 3;
+            } else if (*r == 'x' || *r == 'X') {
+                /* \xNN hex byte */
+                unsigned int val = 0;
+                r++;
+                if (*r) {
+                    char hex[3] = { r[0], r[1] ? r[1] : 0, 0 };
+                    val = (unsigned int)strtoul(hex, NULL, 16);
+                    r++;
+                    if (*r && hex[1]) r++;
+                }
+                *w++ = (char)val;
+            } else {
+                *w++ = *r++;
+            }
+        } else {
+            *w++ = *r++;
+        }
+    }
+    *w = '\0';
+    return (int)(w - s);
+}
+
+/* Write a big-endian 32-bit value */
+static void write_be32(FILE *f, unsigned int val)
+{
+    unsigned char b[4];
+    b[0] = (val >> 24) & 0xFF;
+    b[1] = (val >> 16) & 0xFF;
+    b[2] = (val >>  8) & 0xFF;
+    b[3] = val & 0xFF;
+    fwrite(b, 1, 4, f);
+}
+
+int main(int argc, char *argv[])
+{
+    FILE *fin, *fout;
+    struct CatEntry entries[MAX_STRINGS];
+    int count = 0;
+    char line[MAX_STR_LEN];
+    const char *language;
+    const char *version_str = "$VER: AmigaAI.catalog 0.2 (01.03.2026)";
+    unsigned int strs_size, fver_len, form_size;
+    int i;
+
+    if (argc < 4) {
+        fprintf(stderr, "Usage: %s <input.txt> <output.catalog> <language> [version]\n",
+                argv[0]);
+        return 1;
+    }
+
+    language = argv[3];
+    if (argc > 4)
+        version_str = argv[4];
+
+    fin = fopen(argv[1], "r");
+    if (!fin) {
+        fprintf(stderr, "Cannot open input: %s\n", argv[1]);
+        return 1;
+    }
+
+    /* Parse input file */
+    while (fgets(line, sizeof(line), fin)) {
+        char *nl;
+        int id;
+
+        /* Strip newline */
+        nl = strchr(line, '\n');
+        if (nl) *nl = '\0';
+        nl = strchr(line, '\r');
+        if (nl) *nl = '\0';
+
+        /* Skip comments and empty lines */
+        if (line[0] == ';' || line[0] == '\0')
+            continue;
+
+        /* Try to parse as ID number */
+        if (line[0] >= '0' && line[0] <= '9') {
+            id = atoi(line);
+
+            /* Read the next line as the string */
+            if (!fgets(line, sizeof(line), fin))
+                break;
+            nl = strchr(line, '\n');
+            if (nl) *nl = '\0';
+            nl = strchr(line, '\r');
+            if (nl) *nl = '\0';
+
+            if (count < MAX_STRINGS) {
+                entries[count].id = id;
+                strncpy(entries[count].str, line, MAX_STR_LEN - 1);
+                entries[count].str[MAX_STR_LEN - 1] = '\0';
+                parse_escapes(entries[count].str);
+                count++;
+            }
+        }
+    }
+    fclose(fin);
+
+    printf("Parsed %d strings for language '%s'\n", count, language);
+
+    /* Calculate STRS chunk size.
+     * Each entry: 4-byte ID + 4-byte length + string data padded to 4 bytes.
+     * FlexCat/CatComp pad string data to LONG (4-byte) boundary. */
+    strs_size = 0;
+    for (i = 0; i < count; i++) {
+        int slen = (int)strlen(entries[i].str) + 1; /* include NUL */
+        int padded = (slen + 3) & ~3;               /* round up to 4 */
+        strs_size += 4;       /* ID */
+        strs_size += 4;       /* string length */
+        strs_size += padded;  /* string data padded to 4-byte boundary */
+    }
+
+    /* FVER string (NUL-terminated) */
+    fver_len = (unsigned int)strlen(version_str) + 1;
+
+    /* FORM size = CTLG(4) + FVER chunk(8+fver) + CSET chunk(8+32) + STRS chunk(8+strs) */
+    form_size = 4;                      /* "CTLG" */
+    form_size += 8 + fver_len;          /* FVER chunk */
+    if (fver_len & 1) form_size++;      /* pad */
+    form_size += 8 + 32;               /* CSET chunk (32 bytes data) */
+    form_size += 8 + strs_size;         /* STRS chunk */
+
+    /* Write output */
+    fout = fopen(argv[2], "wb");
+    if (!fout) {
+        fprintf(stderr, "Cannot create output: %s\n", argv[2]);
+        return 1;
+    }
+
+    /* FORM header */
+    fwrite("FORM", 1, 4, fout);
+    write_be32(fout, form_size);
+    fwrite("CTLG", 1, 4, fout);
+
+    /* FVER chunk (must come before CSET per FlexCat/CatComp convention) */
+    fwrite("FVER", 1, 4, fout);
+    write_be32(fout, fver_len);
+    fwrite(version_str, 1, fver_len, fout);
+    if (fver_len & 1)
+        fputc(0, fout);  /* pad to even */
+
+    /* CSET chunk - 32 bytes: CodeSet(4) + Reserved[7](28) */
+    {
+        unsigned char cset_data[32];
+        memset(cset_data, 0, 32);
+        /* cset_data[0..3] = 0 = ISO-8859-1 */
+        fwrite("CSET", 1, 4, fout);
+        write_be32(fout, 32);
+        fwrite(cset_data, 1, 32, fout);
+    }
+
+    /* STRS chunk */
+    fwrite("STRS", 1, 4, fout);
+    write_be32(fout, strs_size);
+
+    for (i = 0; i < count; i++) {
+        int slen = (int)strlen(entries[i].str) + 1;
+        int padded = (slen + 3) & ~3;  /* round up to 4 */
+        int pad = padded - slen;
+        write_be32(fout, (unsigned int)entries[i].id);
+        write_be32(fout, (unsigned int)padded);
+        fwrite(entries[i].str, 1, slen, fout);
+        while (pad-- > 0)
+            fputc(0, fout);  /* pad to 4-byte boundary */
+    }
+
+    fclose(fout);
+    printf("Wrote %s (%u bytes STRS data)\n", argv[2], strs_size);
+
+    return 0;
+}


### PR DESCRIPTION
Implement AmigaOS locale.library support with 91 localizable strings covering menus, buttons, status messages, dialogs and help text. German translation included as IFF CTLG catalog file.

- src/locale.c/h: GetString() with OpenCatalogA/GetCatalogStr
- catalogs/deutsch.txt: German translations with Latin-1 escapes
- tools/mkcatalog.c: Host tool to build IFF CTLG binary catalogs
- Catalogs/Deutsch/AmigaAI.catalog: Compiled German catalog
- src/gui.c, src/main.c: Replace hardcoded strings with GetString()
- build.sh: Compile locale.c, build mkcatalog and generate catalogs
- instructions/ARexx/AMIGAAI.md: Document own ARexx port commands